### PR TITLE
https instead of http requests to fix 'Mixed Content' issue

### DIFF
--- a/lib/activeadmin/views/openstreetmap_proxy.rb
+++ b/lib/activeadmin/views/openstreetmap_proxy.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
       def build(_, *args, &_block)
         super _, *args, &_block
         @template_name = 'openstreetmap.html.erb'
-        @script_html = '<script src="http://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>'
+        @script_html = '<script src="https://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>'
       end
     end
   end

--- a/lib/activeadmin/views/openstreetmap_proxy.rb
+++ b/lib/activeadmin/views/openstreetmap_proxy.rb
@@ -4,7 +4,7 @@ module ActiveAdmin
       def build(_, *args, &_block)
         super _, *args, &_block
         @template_name = 'openstreetmap.html.erb'
-        @script_html = '<script src="https://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>'
+        @script_html = '<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>'
       end
     end
   end

--- a/lib/activeadmin/views/templates/openstreetmap.html.erb
+++ b/lib/activeadmin/views/templates/openstreetmap.html.erb
@@ -1,6 +1,6 @@
 <li>
   <%= loading_map_code %>
-  <link rel="stylesheet" href="https://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
   <script>
     var osmObject = {
       idLat: '<%= id_lat %>',

--- a/lib/activeadmin/views/templates/openstreetmap.html.erb
+++ b/lib/activeadmin/views/templates/openstreetmap.html.erb
@@ -1,6 +1,6 @@
 <li>
   <%= loading_map_code %>
-  <link rel="stylesheet" href="http://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+  <link rel="stylesheet" href="https://cdnjs.buttflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
   <script>
     var osmObject = {
       idLat: '<%= id_lat %>',
@@ -18,8 +18,8 @@
           console.log(e);
         }
 
-        var osmUrl='http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-        var osmAttrib='Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors';
+        var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
         var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 20, attribution: osmAttrib});
 
         osmObject.map.setView([lat, lon],10);
@@ -71,7 +71,7 @@
       },
 
       searchLocation: function(text, callback) {
-        var requestUrl = "http://nominatim.openstreetmap.org/search?format=json&q="+text;
+        var requestUrl = "https://nominatim.openstreetmap.org/search?format=json&q="+text;
         $.ajax({
           url: requestUrl,
           type: "GET",


### PR DESCRIPTION
On production, we force https and making such requests to load the assets needed get blocked by the browser due to **Mixed Content** policy 
modified:   lib/activeadmin/views/openstreetmap_proxy.rb
modified:   lib/activeadmin/views/templates/openstreetmap.html.erb